### PR TITLE
Textidote GitHub action

### DIFF
--- a/.github/workflows/textidote.yml
+++ b/.github/workflows/textidote.yml
@@ -1,5 +1,8 @@
 name: Lint LaTeX document
-on: [push]
+on:
+    push:
+        paths:
+            - '**.tex'
 jobs:
     lint_latex:
         runs-on: ubuntu-latest

--- a/.github/workflows/textidote.yml
+++ b/.github/workflows/textidote.yml
@@ -1,0 +1,30 @@
+name: Lint LaTeX document
+on: [push]
+jobs:
+    lint_latex:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Set up Git repository
+              uses: actions/checkout@v2
+            - name: Lint LaTeX document
+              uses: ChiefGokhlayeh/textidote-action@v4
+              id: lint
+              with:
+                  root_file: final-design-document/finaldesigndoc.tex
+
+                  ## Implied defaults:
+                  # working_directory:
+                  # report_type: html
+                  # report_file: report.html
+
+                  ## Use this setting to pass custom arguments options to
+                  ## TeXtidote (such as what grammar checker to use).
+                  args: --check en
+            - name: Upload TeXtidote report
+              uses: actions/upload-artifact@v2
+              with:
+                  name: textidote_report
+                  path: report.html
+            - name: Throw error if linter warnings exist
+              if: ${{ steps.lint.outputs.num_warnings != 0 }}
+              run: 'echo "::error file=main.tex::num_warnings: ${{ steps.lint.outputs.num_warnings }}"; exit 1;'

--- a/.github/workflows/textidote.yml
+++ b/.github/workflows/textidote.yml
@@ -11,14 +11,6 @@ jobs:
               id: lint
               with:
                   root_file: final-design-document/finaldesigndoc.tex
-
-                  ## Implied defaults:
-                  # working_directory:
-                  # report_type: html
-                  # report_file: report.html
-
-                  ## Use this setting to pass custom arguments options to
-                  ## TeXtidote (such as what grammar checker to use).
                   args: --check en
             - name: Upload TeXtidote report
               uses: actions/upload-artifact@v2
@@ -27,4 +19,4 @@ jobs:
                   path: report.html
             - name: Throw error if linter warnings exist
               if: ${{ steps.lint.outputs.num_warnings != 0 }}
-              run: 'echo "::error file=main.tex::num_warnings: ${{ steps.lint.outputs.num_warnings }}"; exit 1;'
+              run: 'echo "::error file=main.tex::num_warnings: ${{ steps.lint.outputs.num_warnings }}"; exit 0;'

--- a/.github/workflows/textidote.yml
+++ b/.github/workflows/textidote.yml
@@ -11,7 +11,7 @@ jobs:
               id: lint
               with:
                   root_file: final-design-document/finaldesigndoc.tex
-                  args: --check en
+                  args: --check en --remove-macros blindtext
             - name: Upload TeXtidote report
               uses: actions/upload-artifact@v2
               with:


### PR DESCRIPTION
This PR adds a GitHub Action that runs a spell and grammar check against our final design doc.

It uses [TeXtidote](https://sylvainhalle.github.io/textidote/), which runs our LaTeX code against [languagetool](https://languagetool.org/).

This action doesn't enforce anything, just provides a TeXtidote report as an artifact that we can check our code against. It has a lot of false positives, so its just something for us to check against personally. 