### PR TITLE
Run textidote actions on pull request events

### DIFF
--- a/.github/workflows/textidote.yml
+++ b/.github/workflows/textidote.yml
@@ -1,6 +1,6 @@
 name: Lint LaTeX document
 on:
-    push:
+    pull_request:
         paths:
             - '**.tex'
 jobs:


### PR DESCRIPTION
This should fix the GitHub action not being triggered on remote pull requests.